### PR TITLE
feat: add modal pop up for site plan list

### DIFF
--- a/src/pages/field-tech/AddDensityTest.tsx
+++ b/src/pages/field-tech/AddDensityTest.tsx
@@ -10,9 +10,20 @@ import {
   InputAdornment,
   Select,
   MenuItem,
-  Autocomplete,
+  Modal,
+  IconButton,
 } from "@mui/material";
+import { Add as AddIcon, Close as CloseIcon } from "@mui/icons-material";
+import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+// import { useNavigate } from "react-router-dom";
+
+type SitePlan = {
+  id: number;
+  name: string;
+  src: string;
+  dateCreated: string;
+};
 
 type FormFields = {
   location: string;
@@ -43,10 +54,45 @@ const AddDensityTest = () => {
       density: undefined,
       moistureContent: undefined,
       compactionPercentage: undefined,
-      sitePlan: "",
+      sitePlan: "Default site plan",
     },
   });
-  const { register, handleSubmit, control, watch } = form;
+  const { register, handleSubmit, control, watch, setValue } = form;
+  const [open, setOpen] = useState(false);
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+  const handleNewSitePlan = () => {
+    console.log("New site plan");
+  };
+  const handleSelectSitePlan = (sitePlan: SitePlan) => {
+    setOpen(false);
+    setValue("sitePlan", sitePlan.name, { shouldValidate: true });
+    console.log("Site plan selected:", sitePlan);
+  };
+
+  const sitePlans = [
+    {
+      id: 1,
+      name: "Site plan 1",
+      src: "https://placehold.co/125",
+      dateCreated: "Today",
+    },
+    {
+      id: 2,
+      name: "Site plan 2",
+      src: "https://placehold.co/125",
+      dateCreated: "Yesterday",
+    },
+    {
+      id: 3,
+      name: "Site plan 3",
+
+      src: "https://placehold.co/125",
+      dateCreated: "Two weeks ago",
+    },
+  ];
 
   const [probeDepthUnit, compactionSpecificationUnit] = watch([
     "probeDepthUnit",
@@ -57,7 +103,12 @@ const AddDensityTest = () => {
   const onSubmit = (data: FormFields) => {
     console.log(data);
   };
-  const sitePlanOptions = ["Site plan 1", "Site plan 2"];
+  // const navigate = useNavigate();
+  // const sitePlanOptions = ["Site plan 1", "Site plan 2"];
+  const handleChangeClick = () => {
+    // navigate(`/job/${jobId}/all-site-plans`);
+    setOpen(true);
+  };
 
   return (
     <>
@@ -208,31 +259,7 @@ const AddDensityTest = () => {
           <Stack id="density-shot-placement" sx={{ mb: 2 }} gap={2}>
             <Typography variant="h5"> Density Shot Location</Typography>
             <Stack gap={1}>
-              {/* <Autocomplete
-                {...register("sitePlan")}
-                options={sitePlanOptions}
-                freeSolo
-                renderInput={(params) => (
-                  label
-                  <TextField
-                    {...params}
-                    size="small"
-                    sx={{
-                      "& .MuiOutlinedInput-root": {
-                        // backgroundColor: "white",
-                        // borderRadius: 1,
-                      },
-                    }}
-                  />
-                )}
-                sx={{
-                  flex: 1,
-                  "& .MuiAutocomplete-popupIndicator": {
-                    color: "#666",
-                  },
-                }}
-              /> */}
-              <Controller
+              {/* <Controller
                 name="sitePlan"
                 control={control}
                 render={({ field }) => (
@@ -245,6 +272,34 @@ const AddDensityTest = () => {
                     renderInput={(params) => (
                       <TextField {...params} label="Site Plans" />
                     )}
+                  />
+                )}
+              /> */}
+              <Controller
+                name="sitePlan"
+                control={control}
+                render={({ field }) => (
+                  <TextField
+                    {...field}
+                    label="Site Plan"
+                    InputProps={{
+                      readOnly: true,
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <Typography
+                            variant="body2"
+                            onClick={handleChangeClick}
+                            style={{
+                              cursor: "pointer",
+                              textDecoration: "underline",
+                              color: "primary",
+                            }}
+                          >
+                            Change
+                          </Typography>
+                        </InputAdornment>
+                      ),
+                    }}
                   />
                 )}
               />
@@ -291,6 +346,134 @@ const AddDensityTest = () => {
           </Stack>
         </form>
       </Container>
+      <Modal open={open} onClose={handleClose}>
+        {/* Overlay */}
+        <Box
+          sx={{
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: "100vw",
+            height: "100vh",
+            bgcolor: "rgba(0,0,0,0.6)",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            p: 2,
+          }}
+        >
+          {/* Modal content */}
+          <Box
+            sx={{
+              position: "relative",
+              width: "100%",
+              maxHeight: "80vh",
+              maxWidth: "400px",
+              backgroundColor: "white",
+              borderRadius: 2,
+              overflow: "hidden",
+            }}
+          >
+            <IconButton
+              onClick={handleClose}
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                color: "black",
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+            <Box
+              sx={{
+                borderRadius: 2,
+                maxHeight: "80vh",
+                overflowY: "auto",
+                p: 2,
+                pt: 5,
+              }}
+            >
+              {open && (
+                <>
+                  <Box
+                    sx={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      m: 2,
+                    }}
+                  >
+                    <Typography variant="h6">Site Plans</Typography>
+                    <Button
+                      variant="contained"
+                      disableElevation
+                      sx={{
+                        borderRadius: 10,
+                      }}
+                      onClick={handleNewSitePlan}
+                    >
+                      <AddIcon />
+                    </Button>
+                  </Box>
+                  <Stack spacing={3}>
+                    {sitePlans.map((sitePlan) => (
+                      <Box
+                        onClick={() => handleSelectSitePlan(sitePlan)}
+                        key={sitePlan.id}
+                        sx={{
+                          display: "flex",
+                          justifyContent: "center",
+                          flexDirection: "column",
+                          alignItems: "center",
+                          cursor: "pointer",
+                        }}
+                      >
+                        <Box
+                          component="img"
+                          sx={{
+                            borderRadius: 2,
+                            width: "80%",
+                            mb: 1,
+                          }}
+                          alt="Report photos"
+                          src={sitePlan.src}
+                        />
+                        <Box
+                          sx={{
+                            width: "80%",
+                          }}
+                        >
+                          <Typography
+                            variant="body1"
+                            noWrap
+                            sx={{
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            Fig {sitePlan.id}: {sitePlan.name}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            noWrap
+                            sx={{
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {sitePlan.dateCreated}
+                          </Typography>
+                        </Box>
+                      </Box>
+                    ))}
+                  </Stack>
+                </>
+              )}
+            </Box>
+          </Box>
+        </Box>
+      </Modal>
     </>
   );
 };


### PR DESCRIPTION
Create the page of "all site plans" 
https://irenecheung.atlassian.net/jira/software/projects/DRT/boards/1?selectedIssue=DRT-30

- Made a modification, instead of having a separate page for the list of site plans, made it into a pop up modal when we click "Change". Let me know your thoughts on this.

<img width="474" height="119" alt="image" src="https://github.com/user-attachments/assets/04f4a537-888c-491e-aa80-0ab179ca5cc6" />

<img width="484" height="890" alt="image" src="https://github.com/user-attachments/assets/2c8bcdde-a81f-4a5d-bfbf-c145d1a26ba9" />
