### PR TITLE
Drt 53 add docker workflows

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,17 @@
+# Use Node 18 for development
+FROM node:18-alpine AS dev
+
+WORKDIR /app
+
+# Install dependencies first (cached layers)
+COPY package*.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Expose Vite dev server port
+EXPOSE 5173
+
+# Run Vite in host mode so it is accessible outside the container
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173", "--open=false"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In this project:
 
 # Setup
 
-## Local
+## Docker Dev (recommended)
 
 ### 1. clone the repository
 
@@ -35,14 +35,9 @@ In this project:
 git clone https://github.com/Density-Reporting-Tool/DensityReportingToolFrontend.git
 ```
 
-### 2. Install Dependencies
+### 2. Add your secret .env file
 
-Use npm ci for consistency based on package-lock.json
-
-```bash
-cd DensityReportingToolFrontend
-npm ci
-```
+Refer to .env.example for a template
 
 ### 3. Verify linters and Commit Hooks
 
@@ -53,12 +48,44 @@ npm install husky@latest --save-dev
 npx husky install
 ```
 
-### 4. Run the development server
+### 4. build and run the container
+
+```bash
+docker compose up --build
+```
+
+## Local Dev
+
+### 1. clone the repository
+
+```bash
+git clone https://github.com/Density-Reporting-Tool/DensityReportingToolFrontend.git
+```
+
+### 2. Add your secret .env file
+
+look at env.example for formatting
+
+### 3. Install Dependencies
+
+Use npm ci for consistency based on package-lock.json
+
+```bash
+cd DensityReportingToolFrontend
+npm ci
+```
+
+### 4. Verify linters and Commit Hooks
+
+get the latest version of husky
+
+```bash
+npm install husky@latest --save-dev
+npx husky install
+```
+
+### 5. Run the development server
 
 ```bash
 npm run dev
 ```
-
-## Docker
-
-### 1. TODO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    container_name: density-frontend-dev
+    ports:
+      - "5173:5173"  # Vite dev server
+    volumes:
+      - .:/app:cached
+      - /app/node_modules
+    env_file:
+      - .env       # load all variables from your existing .env

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,6 +92,10 @@ export default defineConfig({
   server: {
     port: 3000,
     open: true,
+    watch: {
+      usePolling: true, // Check docker mounted files for changes
+      interval: 500, // Check every 500ms
+    },
     proxy:
       process.env.NODE_ENV === "development"
         ? {


### PR DESCRIPTION
Enabled running frontend locally in a container that supports live reload and communicates with the backend container
Updated README to give instructions on how to run